### PR TITLE
Algebra to post GitHub comments

### DIFF
--- a/modules/core/src/main/scala/com.fortysevendeg.hood/github/GithubService.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/github/GithubService.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fortysevendeg.hood.github
+
+import cats.Functor
+import cats.effect.Sync
+import github4s.GithubResponses.GHException
+import github4s.Github
+import github4s.Github._
+import github4s.cats.effect.jvm.Implicits._
+import cats.implicits._
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+
+trait GithubService[F[_]] {
+
+  type GithubPublishResult = Either[GHException, Unit]
+
+  def publishComment(
+      accessToken: String,
+      owner: String,
+      repository: String,
+      pullRequestNumber: Int,
+      comment: String): F[GithubPublishResult]
+
+}
+
+object GithubService {
+
+  def build[F[_]](implicit S: Sync[F]): F[GithubService[F]] = S.delay(new GithubServiceImpl[F])
+
+  class GithubServiceImpl[F[_]](implicit S: Sync[F], F: Functor[F]) extends GithubService[F] {
+    def publishComment(
+        accessToken: String,
+        owner: String,
+        repository: String,
+        pullRequestNumber: Int,
+        comment: String): F[GithubPublishResult] = {
+
+      for {
+        logger <- Slf4jLogger.create[F]
+        result <- Github(Some(accessToken)).issues
+          .createComment(owner, repository, pullRequestNumber, comment)
+          .exec()
+          .onError { case e => logger.error(e)("Found error while accessing GitHub API.") }
+
+      } yield result
+
+      F.map(
+        Github(Some(accessToken)).issues
+          .createComment(owner, repository, pullRequestNumber, comment)
+          .exec()) { result =>
+        result
+          .map(_ => ())
+      }
+    }
+  }
+
+}

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/github/GithubService.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/github/GithubService.scala
@@ -40,7 +40,7 @@ trait GithubService[F[_]] {
 
 object GithubService {
 
-  def build[F[_]](implicit S: Sync[F], L: Logger[F]): GithubService[F] = new GithubServiceImpl[F]
+  def build[F[_]: Sync: Logger]: GithubService[F] = new GithubServiceImpl[F]
 
   class GithubServiceImpl[F[_]: Sync: Functor](implicit L: Logger[F]) extends GithubService[F] {
 

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/model/Benchmark.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/model/Benchmark.scala
@@ -26,7 +26,7 @@ final case class Benchmark(
 )
 
 object Benchmark {
-  implicit val benchmarkDecoder: Decoder[Benchmark]  = deriveDecoder[Benchmark]
+  implicit val benchmarkDecoder: Decoder[Benchmark] = deriveDecoder[Benchmark]
   implicit val benchmarkEncoder: Encoder[Benchmark] = deriveEncoder[Benchmark]
 }
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -29,7 +29,10 @@ object ProjectPlugin extends AutoPlugin {
       val scala: String         = "2.12.8"
       val scalatest: String     = "3.0.6"
       val slf4j: String         = "1.7.26"
-      val circe:String = "0.11.1"
+      val circe: String         = "0.11.1"
+      val github4s: String      = "0.20.1"
+      val cats: String          = "2.0.0-M1"
+      val log4cats: String      = "0.4.0-M1"
     }
 
     lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
@@ -98,9 +101,13 @@ object ProjectPlugin extends AutoPlugin {
       addCompilerPlugin(%%("paradise", V.paradise) cross CrossVersion.full),
       addCompilerPlugin(%%("kind-projector", V.kindProjector) cross CrossVersion.binary),
       libraryDependencies ++= Seq(
-        "io.circe"                       %% "circe-generic"   % V.circe,
-        "io.circe"                       %% "circe-core"      % V.circe,
-        "io.circe"                       %% "circe-parser"    % V.circe,
+        "io.circe"          %% "circe-generic"          % V.circe,
+        "io.circe"          %% "circe-core"             % V.circe,
+        "io.circe"          %% "circe-parser"           % V.circe,
+        "com.47deg"         %% "github4s"               % V.github4s,
+        "com.47deg"         %% "github4s-cats-effect"   % V.github4s,
+        "org.typelevel"     %% "cats-effect"            % V.cats,
+        "io.chrisdavenport" %% "log4cats-slf4j"         % V.log4cats,
         %%("scalatest", V.scalatest) % "test",
         %("slf4j-nop", V.slf4j)      % Test
       )

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -24,15 +24,16 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val kindProjector: String = "0.9.9"
-      val paradise: String      = "2.1.1"
-      val scala: String         = "2.12.8"
-      val scalatest: String     = "3.0.6"
-      val slf4j: String         = "1.7.26"
-      val circe: String         = "0.11.1"
-      val github4s: String      = "0.20.1"
-      val cats: String          = "2.0.0-M1"
-      val log4cats: String      = "0.4.0-M1"
+      val kindProjector: String   = "0.9.9"
+      val paradise: String        = "2.1.1"
+      val scala: String           = "2.12.8"
+      val scalatest: String       = "3.0.6"
+      val slf4j: String           = "1.7.26"
+      val circe: String           = "0.11.1"
+      val github4s: String        = "0.20.1"
+      val cats: String            = "2.0.0-M1"
+      val log4cats: String        = "0.4.0-M1"
+      val logbackClassic: String  = "1.2.3"
     }
 
     lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
@@ -101,13 +102,14 @@ object ProjectPlugin extends AutoPlugin {
       addCompilerPlugin(%%("paradise", V.paradise) cross CrossVersion.full),
       addCompilerPlugin(%%("kind-projector", V.kindProjector) cross CrossVersion.binary),
       libraryDependencies ++= Seq(
-        "io.circe"          %% "circe-generic"          % V.circe,
-        "io.circe"          %% "circe-core"             % V.circe,
-        "io.circe"          %% "circe-parser"           % V.circe,
-        "com.47deg"         %% "github4s"               % V.github4s,
-        "com.47deg"         %% "github4s-cats-effect"   % V.github4s,
-        "org.typelevel"     %% "cats-effect"            % V.cats,
-        "io.chrisdavenport" %% "log4cats-slf4j"         % V.log4cats,
+        "io.circe"                   %% "circe-generic"          % V.circe,
+        "io.circe"                   %% "circe-core"             % V.circe,
+        "io.circe"                   %% "circe-parser"           % V.circe,
+        "com.47deg"                  %% "github4s"               % V.github4s,
+        "com.47deg"                  %% "github4s-cats-effect"   % V.github4s,
+        "org.typelevel"              %% "cats-effect"            % V.cats,
+        "io.chrisdavenport"          %% "log4cats-slf4j"         % V.log4cats,
+        "ch.qos.logback"              % "logback-classic"        % V.logbackClassic,
         %%("scalatest", V.scalatest) % "test",
         %("slf4j-nop", V.slf4j)      % Test
       )


### PR DESCRIPTION
Fixes #6

This PR introduces a simple algebra to push comments into an existing PR, in order for the plugin to submit benchmark comparisons when sending pushes to one.