### PR TITLE
Adding methods to edit/list comments from GitHub repos

### DIFF
--- a/modules/core/src/main/scala/com.fortysevendeg.hood/github/GithubService.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/github/GithubService.scala
@@ -16,25 +16,36 @@
 
 package com.fortysevendeg.hood.github
 
-import cats.Functor
 import cats.effect.Sync
-import github4s.GithubResponses.GHException
 import github4s.Github
 import github4s.Github._
 import github4s.cats.effect.jvm.Implicits._
 import cats.implicits._
+import github4s.GithubResponses.GHResponse
+import github4s.free.domain.{Comment, Status}
 import io.chrisdavenport.log4cats.Logger
 
 trait GithubService[F[_]] {
-
-  type GithubPublishResult = Either[GHException, Unit]
 
   def publishComment(
       accessToken: String,
       owner: String,
       repository: String,
       pullRequestNumber: Int,
-      comment: String): F[GithubPublishResult]
+      comment: String): F[GHResponse[Comment]]
+
+  def editComment(
+      accessToken: String,
+      owner: String,
+      repository: String,
+      commentId: Int,
+      comment: String): F[GHResponse[Comment]]
+
+  /*def createStatus(
+                    accessToken: String,
+                    owner: String,
+                    repository: String,
+                    state: String): F[GHResponse[Status]]*/
 
 }
 
@@ -42,26 +53,54 @@ object GithubService {
 
   def build[F[_]: Sync: Logger]: GithubService[F] = new GithubServiceImpl[F]
 
-  class GithubServiceImpl[F[_]: Sync: Functor](implicit L: Logger[F]) extends GithubService[F] {
+  class GithubServiceImpl[F[_]: Sync](implicit L: Logger[F]) extends GithubService[F] {
 
     def publishComment(
         accessToken: String,
         owner: String,
         repository: String,
         pullRequestNumber: Int,
-        comment: String): F[GithubPublishResult] = {
+        comment: String): F[GHResponse[Comment]] = {
 
       for {
         result <- Github(Some(accessToken)).issues
           .createComment(owner, repository, pullRequestNumber, comment)
           .exec()
           .onError { case e => L.error(e)("Found error while accessing GitHub API.") }
-          .map { _ =>
-            Right(())
-          }
         _ <- L.info("Comment sent to GitHub successfully.")
       } yield result
     }
+
+    def editComment(
+        accessToken: String,
+        owner: String,
+        repository: String,
+        commentId: Int,
+        comment: String): F[GHResponse[Comment]] = {
+
+      for {
+        result <- Github(Some(accessToken)).issues
+          .editComment(owner, repository, commentId, comment)
+          .exec()
+          .onError { case e => L.error(e)("Found error while accessing GitHub API.") }
+        _ <- L.info("Comment edited successfully.")
+      } yield result
+    }
+
+    /*def createStatus(
+                      accessToken: String,
+                      owner: String,
+                      repository: String,
+                      pullRequestNumber: Int,
+                      state: String): F[GHResponse[Status]] = {
+      for {
+        pull <- Github(Some(accessToken)).pullRequests.get(owner, repository, pullRequestNumber)
+        lastSha = pull.map(_.result.)
+
+
+      } yield ()
+
+    }*/
 
   }
 


### PR DESCRIPTION
Just an upgrade on the current code that talks to GitHub4s to have the basic tools to interact with comments in a PR once we're at that stage.