### PR TITLE
Sbt-hood plugin keys and main task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val `sbt-hood-plugin` = project
   .settings(publishLocal := publishLocal
     .dependsOn(`sbt-hood-core` / publishLocal)
     .value)
+  .settings(sbtPlugin := true)
   .enablePlugins(SbtPlugin)
 
 lazy val allModules: Seq[ProjectReference] = Seq(`sbt-hood-core`)

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/benchmark/BenchmarkService.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/benchmark/BenchmarkService.scala
@@ -31,7 +31,7 @@ final case class BenchmarkComparisonResult(
     current: Option[Benchmark],
     result: BenchmarkComparisonStatus,
     threshold: Double) {
-  def icon(): String = {
+  def icon: String = {
     (result match {
       case OK      => "heavy_check_mark"
       case Warning => "warning"

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/benchmark/BenchmarkService.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/benchmark/BenchmarkService.scala
@@ -18,6 +18,9 @@ package com.fortysevendeg.hood.benchmark
 
 import com.fortysevendeg.hood.model.Benchmark
 import scala.math.abs
+import com.lightbend.emoji.Emoji.Implicits._
+import com.lightbend.emoji.ShortCodes.Implicits._
+import com.lightbend.emoji.ShortCodes.Defaults._
 
 sealed trait BenchmarkComparisonStatus extends Product with Serializable
 case object OK                         extends BenchmarkComparisonStatus
@@ -26,8 +29,17 @@ case object Error                      extends BenchmarkComparisonStatus
 
 final case class BenchmarkComparisonResult(
     previous: Benchmark,
-    current: Benchmark,
-    result: BenchmarkComparisonStatus)
+    current: Option[Benchmark],
+    result: BenchmarkComparisonStatus,
+    threshold: Double) {
+  def icon(): String = {
+    (result match {
+      case OK      => "heavy_check_mark"
+      case Warning => "warning"
+      case _       => "red_circle"
+    }).emoji.toString()
+  }
+}
 
 object BenchmarkService {
 
@@ -45,8 +57,9 @@ object BenchmarkService {
 
     BenchmarkComparisonResult(
       previousBenchmark,
-      currentBenchmark,
-      status
+      Some(currentBenchmark),
+      status,
+      threshold
     )
   }
 

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/benchmark/BenchmarkService.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/benchmark/BenchmarkService.scala
@@ -18,7 +18,6 @@ package com.fortysevendeg.hood.benchmark
 
 import com.fortysevendeg.hood.model.Benchmark
 import scala.math.abs
-import com.lightbend.emoji.Emoji.Implicits._
 import com.lightbend.emoji.ShortCodes.Implicits._
 import com.lightbend.emoji.ShortCodes.Defaults._
 

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/csv/CsvService.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/csv/CsvService.scala
@@ -28,7 +28,7 @@ import io.chrisdavenport.log4cats.Logger
 
 import scala.io.{BufferedSource, Source}
 
-case class BenchmarkColumns(
+final case class BenchmarkColumns(
     keyCol: String,
     modeCol: String,
     compareCol: String,
@@ -37,7 +37,8 @@ case class BenchmarkColumns(
 
 trait CsvService[F[_]] {
 
-  def parseBenchmark(columns: BenchmarkColumns)(
+  def parseBenchmark(
+      columns: BenchmarkColumns,
       csvFile: File): F[Either[HoodError, List[Benchmark]]]
 
 }
@@ -48,7 +49,8 @@ object CsvService {
 
   class CsvServiceImpl[F[_]](implicit S: Sync[F], L: Logger[F]) extends CsvService[F] {
 
-    def parseBenchmark(columns: BenchmarkColumns)(
+    def parseBenchmark(
+        columns: BenchmarkColumns,
         csvFile: File): F[Either[HoodError, List[Benchmark]]] =
       openFile(csvFile).attempt
         .use(fileData =>

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/model/HoodError.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/model/HoodError.scala
@@ -16,5 +16,6 @@
 
 package com.fortysevendeg.hood.model
 
-sealed trait HoodError                       extends Product with Serializable
-final case class InvalidCsv(message: String) extends HoodError
+sealed trait HoodError                                    extends Product with Serializable
+final case class InvalidCsv(message: String)              extends HoodError
+final case class MissingCurrentBenchmark(message: String) extends HoodError

--- a/modules/core/src/main/scala/com.fortysevendeg.hood/model/HoodError.scala
+++ b/modules/core/src/main/scala/com.fortysevendeg.hood/model/HoodError.scala
@@ -19,3 +19,4 @@ package com.fortysevendeg.hood.model
 sealed trait HoodError                                    extends Product with Serializable
 final case class InvalidCsv(message: String)              extends HoodError
 final case class MissingCurrentBenchmark(message: String) extends HoodError
+final case class BenchmarkLoadingError(message: String)   extends HoodError

--- a/modules/core/src/test/scala/com/fortysevendeg/hood/csv/CsvServiceTests.scala
+++ b/modules/core/src/test/scala/com/fortysevendeg/hood/csv/CsvServiceTests.scala
@@ -32,7 +32,12 @@ class CsvServiceTests extends FlatSpec with Matchers {
   "CsvService" should "parse a correct CSV file" in {
     val dataFile = new File(getClass.getResource("/jmh.csv").getPath)
 
-    val result = CsvService.build[IO].parseBenchmark(dataFile).unsafeRunSync()
+    val result = CsvService
+      .build[IO]
+      .parseBenchmark("Benchmark", "Mode", "Score", "Score Error (99.9%)", "Unit")(dataFile)
+      .unsafeRunSync()
+
+    println(s"Result: ${result}")
 
     result.isRight shouldBe true
     result.map { list =>
@@ -43,7 +48,10 @@ class CsvServiceTests extends FlatSpec with Matchers {
   it should "return an error when loading an invalid CSV file" in {
     val dataFile = new File(getClass.getResource("/invalid_jmh.csv").getPath)
 
-    val result = CsvService.build[IO].parseBenchmark(dataFile).unsafeRunSync()
+    val result = CsvService
+      .build[IO]
+      .parseBenchmark("Benchmark", "Mode", "Score", "Score Error (99.9%)", "Unit")(dataFile)
+      .unsafeRunSync()
 
     result.isLeft shouldBe true
     result.leftMap(_.isInstanceOf[InvalidCsv] shouldBe true)

--- a/modules/core/src/test/scala/com/fortysevendeg/hood/csv/CsvServiceTests.scala
+++ b/modules/core/src/test/scala/com/fortysevendeg/hood/csv/CsvServiceTests.scala
@@ -34,10 +34,10 @@ class CsvServiceTests extends FlatSpec with Matchers {
 
     val result = CsvService
       .build[IO]
-      .parseBenchmark("Benchmark", "Mode", "Score", "Score Error (99.9%)", "Unit")(dataFile)
+      .parseBenchmark(
+        BenchmarkColumns("Benchmark", "Mode", "Score", "Score Error (99.9%)", "Unit"),
+        dataFile)
       .unsafeRunSync()
-
-    println(s"Result: ${result}")
 
     result.isRight shouldBe true
     result.map { list =>
@@ -50,7 +50,9 @@ class CsvServiceTests extends FlatSpec with Matchers {
 
     val result = CsvService
       .build[IO]
-      .parseBenchmark("Benchmark", "Mode", "Score", "Score Error (99.9%)", "Unit")(dataFile)
+      .parseBenchmark(
+        BenchmarkColumns("Benchmark", "Mode", "Score", "Score Error (99.9%)", "Unit"),
+        dataFile)
       .unsafeRunSync()
 
     result.isLeft shouldBe true

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
@@ -18,6 +18,7 @@ package com.fortysevendeg.hood.plugin
 
 import sbt._
 import Keys._
+import com.fortysevendeg.hood.plugin.SbtHoodPlugin._
 
 trait SbtHoodKeys {
 
@@ -71,7 +72,8 @@ trait SbtHoodDefaultSettings extends SbtHoodKeys {
     modeColumnName := "Mode",
     unitsColumnName := "Unit",
     generalThreshold := None,
-    benchmarkThreshold := Map.empty
+    benchmarkThreshold := Map.empty,
+    compareBenchmarks := compareBenchmarksTask.value
   )
 
 }

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.fortysevendeg.hood.plugin
 
 import sbt._
@@ -20,6 +36,10 @@ trait SbtHoodKeys {
     "Column name of the column to compare (values must be `Double`). By default: Score.")
   val thresholdColumnName: SettingKey[String] = settingKey(
     "Column name to get the threshold per benchmark. By default: `Score Error (99.9%)`.")
+  val modeColumnName: SettingKey[String] = settingKey(
+    "Column name to get the benchmark mode. By default: `Mode`.")
+  val unitsColumnName: SettingKey[String] = settingKey(
+    "Column name to get the benchmark mode. By default: `Unit`.")
   val generalThreshold: SettingKey[Option[Double]] = settingKey(
     "Common threshold to all benchmarks overriding the value coming from `thresholdColumnName`. Optional.")
   val benchmarkThreshold: SettingKey[Map[String, Double]] = settingKey(
@@ -42,15 +62,14 @@ object SbtHoodKeys extends SbtHoodKeys
 
 trait SbtHoodDefaultSettings extends SbtHoodKeys {
 
-  import SbtHoodKeys._
-
   def defaultSettings = Seq(
     previousBenchmarkPath := baseDirectory.value / "master.csv",
     currentBenchmarkPath := baseDirectory.value / "current.csv",
-    compareBenchmarks := (Compile / packageBin / artifactPath).value,
     keyColumnName := "Benchmark",
     compareColumnName := "Score",
     thresholdColumnName := "Score Error (99.9%)",
+    modeColumnName := "Mode",
+    unitsColumnName := "Unit",
     generalThreshold := None,
     benchmarkThreshold := Map.empty
   )

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
@@ -1,0 +1,58 @@
+package com.fortysevendeg.hood.plugin
+
+import sbt._
+import Keys._
+
+trait SbtHoodKeys {
+
+  val compareBenchmarks: TaskKey[Unit] =
+    taskKey[Unit]("Compare two benchmarks and show results through the console.")
+  val compareBenchmarksCI: TaskKey[Unit] = taskKey[Unit](
+    "Compare two benchmarks and show results through a GitHub comment in a repository.")
+
+  val previousBenchmarkPath: SettingKey[File] = settingKey(
+    "Path to the previous JMH benchmark in CSV format. By default: {project_root}/master.csv.")
+  val currentBenchmarkPath: SettingKey[File] = settingKey(
+    "Path to the current JMH benchmark in CSV format.  By default: {project_root}/current.csv.")
+  val keyColumnName: SettingKey[String] = settingKey(
+    "Column name to distinguish each benchmark on the comparison. By default: `Benchmark`.")
+  val compareColumnName: SettingKey[String] = settingKey(
+    "Column name of the column to compare (values must be `Double`). By default: Score.")
+  val thresholdColumnName: SettingKey[String] = settingKey(
+    "Column name to get the threshold per benchmark. By default: `Score Error (99.9%)`.")
+  val generalThreshold: SettingKey[Option[Double]] = settingKey(
+    "Common threshold to all benchmarks overriding the value coming from `thresholdColumnName`. Optional.")
+  val benchmarkThreshold: SettingKey[Map[String, Double]] = settingKey(
+    "Map with a custom threshold per benchmark key overriding the value coming from `thresholdColumnName` or `generalThreshold`. Optional.")
+
+  val gitHubToken: SettingKey[String] = settingKey(
+    "GitHub access token required by `compareBenchmarksCI`.")
+  val gitHubUserId: SettingKey[String] = settingKey(
+    "GitHub ID for the user publishing the benchmark comments, required by `compareBenchmarksCI`.")
+  val repositoryOwner: SettingKey[String] = settingKey(
+    "Owner of the repository where the plugin will post updates, required by `compareBenchmarksCI`.")
+  val repositoryName: SettingKey[String] = settingKey(
+    "Name of the repository where the plugin will post updates, required by `compareBenchmarksCI`.")
+  val pullRequestNumber: SettingKey[Int] = settingKey(
+    "Pull request number where the plugin will post updates, required by `compareBenchmarksCI`.")
+
+}
+
+object SbtHoodKeys extends SbtHoodKeys
+
+trait SbtHoodDefaultSettings extends SbtHoodKeys {
+
+  import SbtHoodKeys._
+
+  def defaultSettings = Seq(
+    previousBenchmarkPath := baseDirectory.value / "master.csv",
+    currentBenchmarkPath := baseDirectory.value / "current.csv",
+    compareBenchmarks := (Compile / packageBin / artifactPath).value,
+    keyColumnName := "Benchmark",
+    compareColumnName := "Score",
+    thresholdColumnName := "Score Error (99.9%)",
+    generalThreshold := None,
+    benchmarkThreshold := Map.empty
+  )
+
+}

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -53,8 +53,8 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
         EitherT.left[List[BenchmarkComparisonResult]](logger.error(s"There was an error: $e")))
       .value
       .unsafeRunSync()
-
-    ()
+      .void
+      .merge
   }
 
   def benchmarkTask[F[_]](
@@ -74,17 +74,18 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
 
     val csvService = CsvService.build[F]
 
-    val parseFunction: File => F[Either[HoodError, List[Benchmark]]] = csvService.parseBenchmark(
-      BenchmarkColumns(
-        keyColumnName,
-        modeColumnName,
-        compareColumnName,
-        thresholdColumnName,
-        unitsColumnName))
+    val columns = BenchmarkColumns(
+      keyColumnName,
+      modeColumnName,
+      compareColumnName,
+      thresholdColumnName,
+      unitsColumnName)
 
     for {
-      previousBenchmarks <- EitherT(parseFunction(previousPath)).map(buildBenchmarkMap)
-      currentBenchmarks  <- EitherT(parseFunction(currentPath)).map(buildBenchmarkMap)
+      previousBenchmarks <- EitherT(csvService.parseBenchmark(columns, previousPath))
+        .map(buildBenchmarkMap)
+      currentBenchmarks <- EitherT(csvService.parseBenchmark(columns, currentPath))
+        .map(buildBenchmarkMap)
       result <- EitherT.right[HoodError](
         performBenchmarkComparison[F](
           currentBenchmarks,
@@ -106,10 +107,9 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
       generalThreshold: Option[Double],
       thresholdMap: Map[String, Double])(
       implicit L: Logger[F],
-      S: Sync[F],
-      M: Monad[F]): F[List[BenchmarkComparisonResult]] =
-    previousBenchmarks
-      .map {
+      S: Sync[F]): F[List[BenchmarkComparisonResult]] =
+    previousBenchmarks.toList
+      .traverse {
         case (benchmarkKey, previous) =>
           val threshold =
             thresholdMap
@@ -118,15 +118,12 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
 
           currentBenchmarks
             .get(benchmarkKey)
-            .fold({
-              M.flatMap(L.error(
-                s"Benchmark $benchmarkKey existing in previous benchmarks is missing from current ones."))(
-                _ => S.delay(BenchmarkComparisonResult(previous, None, Warning, threshold)))
-
-            })(current => S.delay(BenchmarkService.compare(current, previous, threshold)))
+            .fold(
+              L.error(
+                  s"Benchmark $benchmarkKey existing in previous benchmarks is missing from current ones.")
+                .as(BenchmarkComparisonResult(previous, None, Warning, threshold))
+            )(current => S.delay(BenchmarkService.compare(current, previous, threshold)))
       }
-      .toList
-      .sequence
 
   private[this] def benchmarkOutput(
       benchmarks: List[BenchmarkComparisonResult],
@@ -134,13 +131,13 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
       currentFile: String): String = {
     def outputComparisonResult(result: BenchmarkComparisonResult): String =
       s"""
-         |${result.icon()} ${result.previous.benchmark} (Threshold: ${result.threshold})
+         |${result.icon} ${result.previous.benchmark} (Threshold: ${result.threshold})
          |
       |Benchmark|Value
          |$previousFile|${result.previous.primaryMetric.score.toString}
          |$currentFile|${result.current.map(_.primaryMetric.score.toString).getOrElse("N/A")}
     """.stripMargin
 
-    benchmarks.map(b => outputComparisonResult(b)).mkString("")
+    benchmarks.map(outputComparisonResult).mkString("")
   }
 }

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -34,9 +34,9 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
   override def projectSettings: Seq[Def.Setting[_]] = defaultSettings
   override val trigger: PluginTrigger               = noTrigger
 
-  def compareBenchmarksTask: Def.Initialize[Task[Unit]] = Def.task {
+  implicit lazy val logger = Slf4jLogger.getLogger[IO]
 
-    implicit val logger = Slf4jLogger.getLogger[IO]
+  def compareBenchmarksTask: Def.Initialize[Task[Unit]] = Def.task {
 
     benchmarkTask(
       previousBenchmarkPath.value,

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fortysevendeg.hood.plugin
+
+import java.io.File
+
+import cats.data.EitherT
+import cats.effect.{IO, Sync}
+import com.fortysevendeg.hood.benchmark.{BenchmarkComparisonResult, BenchmarkService}
+import com.fortysevendeg.hood.csv.CsvService
+import com.fortysevendeg.hood.model.{Benchmark, HoodError}
+import sbt.{AutoPlugin, Def}
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+
+object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings {
+
+  override def projectSettings: Seq[Def.Setting[_]] = defaultSettings
+
+  def benchmarkTask(
+      previousPath: File,
+      currentPath: File,
+      keyColumnName: String,
+      compareColumnName: String,
+      thresholdColumnName: String,
+      modeColumnName: String,
+      unitsColumnName: String,
+      generalThreshold: Option[Double],
+      benchmarkThreshold: Map[String, Double]): EitherT[
+    IO,
+    HoodError,
+    List[BenchmarkComparisonResult]] = {
+
+    implicit val logger = Slf4jLogger.getLogger[IO]
+    val csvService      = CsvService.build[IO]
+
+    val parseFunction: File => IO[Either[HoodError, List[Benchmark]]] = csvService.parseBenchmark(
+      keyColumnName,
+      modeColumnName,
+      compareColumnName,
+      thresholdColumnName,
+      unitsColumnName)
+
+    for {
+      previousBenchmarks <- EitherT(parseFunction(previousPath)).map(buildBenchmarkMap)
+      currentBenchmarks  <- EitherT(parseFunction(currentPath)).map(buildBenchmarkMap)
+      result <- EitherT.right[HoodError](
+        compareBenchmarks[IO](
+          currentBenchmarks,
+          previousBenchmarks,
+          generalThreshold,
+          benchmarkThreshold))
+    } yield result
+
+  }
+
+  private[this] def buildBenchmarkMap(benchmarks: List[Benchmark]): Map[String, Benchmark] =
+    benchmarks.map(b => (b.benchmark, b)).toMap
+
+  private[this] def compareBenchmarks[F[_]](
+      currentBenchmarks: Map[String, Benchmark],
+      previousBenchmarks: Map[String, Benchmark],
+      generalThreshold: Option[Double],
+      thresholdMap: Map[String, Double])(
+      implicit L: Logger[F],
+      S: Sync[F]): F[List[BenchmarkComparisonResult]] = {
+
+    S.delay(previousBenchmarks.keys.flatMap { benchmarkKey =>
+      val currentBench = currentBenchmarks.get(benchmarkKey)
+
+      if (currentBench.isEmpty) {
+        L.error(
+          s"Benchmark $benchmarkKey existing in previous benchmarks is missing from current ones.")
+      }
+
+      for {
+        previous <- previousBenchmarks.get(benchmarkKey)
+        current  <- currentBench
+        threshold = thresholdMap.getOrElse(benchmarkKey, previous.primaryMetric.scoreError)
+      } yield BenchmarkService.compare(current, previous, threshold)
+    }.toList)
+
+  }
+
+}

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -18,7 +18,6 @@ package com.fortysevendeg.hood.plugin
 
 import java.io.File
 
-import cats.Monad
 import cats.data.EitherT
 import cats.implicits._
 import cats.effect.{Console, IO, Sync}
@@ -69,8 +68,7 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
       benchmarkThreshold: Map[String, Double])(
       implicit L: Logger[F],
       S: Sync[F],
-      C: Console[F],
-      M: Monad[F]): EitherT[F, HoodError, List[BenchmarkComparisonResult]] = {
+      C: Console[F]): EitherT[F, HoodError, List[BenchmarkComparisonResult]] = {
 
     val csvService = CsvService.build[F]
 

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -50,9 +50,9 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
       benchmarkThreshold.value
     ).leftFlatMap(e =>
         EitherT.left[List[BenchmarkComparisonResult]](logger.error(s"There was an error: $e")))
+      .void
       .value
       .unsafeRunSync()
-      .void
       .merge
   }
 

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -132,6 +132,6 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
          |$currentFile|${result.current.map(_.primaryMetric.score.toString).getOrElse("N/A")}
     """.stripMargin
 
-    benchmarks.map(b => outputComparisonResult(b)).mkString("\n\n")
+    benchmarks.map(b => outputComparisonResult(b)).mkString("")
   }
 }

--- a/modules/plugin/src/test/resources/current_better.csv
+++ b/modules/plugin/src/test/resources/current_better.csv
@@ -1,0 +1,3 @@
+"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
+"test.decoding","thrpt",1,20,6.0,0.1,"love/s"
+"test.parsing","thrpt",1,20,7.0,0.1,"love/s"

--- a/modules/plugin/src/test/resources/current_really_bad.csv
+++ b/modules/plugin/src/test/resources/current_really_bad.csv
@@ -1,0 +1,3 @@
+"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
+"test.decoding","thrpt",1,20,1.0,0.1,"love/s"
+"test.parsing","thrpt",1,20,0.5,0.1,"love/s"

--- a/modules/plugin/src/test/resources/current_worse.csv
+++ b/modules/plugin/src/test/resources/current_worse.csv
@@ -1,0 +1,3 @@
+"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
+"test.decoding","thrpt",1,20,3.0,0.1,"love/s"
+"test.parsing","thrpt",1,20,4.0,0.1,"love/s"

--- a/modules/plugin/src/test/resources/previous.csv
+++ b/modules/plugin/src/test/resources/previous.csv
@@ -1,0 +1,3 @@
+"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
+"test.decoding","thrpt",1,20,5.0,3.0,"love/s"
+"test.parsing","thrpt",1,20,6.0,3.0,"love/s"

--- a/modules/plugin/src/test/scala/com.fortysevendeg.hood.plugin/SbtHoodPluginTests.scala
+++ b/modules/plugin/src/test/scala/com.fortysevendeg.hood.plugin/SbtHoodPluginTests.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scala.com.fortysevendeg.hood.plugin
+
+import java.io.File
+
+import cats.effect.IO
+import com.fortysevendeg.hood.benchmark.BenchmarkComparisonResult
+import com.fortysevendeg.hood.plugin.SbtHoodPlugin
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.scalatest.{FlatSpec, Matchers}
+import cats.effect.Console.implicits._
+
+class SbtHoodPluginTests extends FlatSpec with Matchers with TestUtils {
+
+  implicit val logger = Slf4jLogger.getLogger[IO]
+
+  val previousFile = new File(getClass.getResource("/previous.csv").getPath)
+
+  "SbtHoodPlugin" should "compare two benchmarks and return a valid result if the current one is better with default settings" in {
+    val currentFile = new File(getClass.getResource("/current_better.csv").getPath)
+
+    checkComparisonDefaultThreshold(currentFile, benchmarkResultAgainstNiceDefault)
+  }
+
+  it should "compare two benchmarks and return a warning if the current one is worse (but under threshold) with default settings" in {
+    val currentFile = new File(getClass.getResource("/current_worse.csv").getPath)
+
+    checkComparisonDefaultThreshold(currentFile, benchmarkResultAgainstNotSoNiceDefault)
+  }
+
+  it should "compare two benchmarks and return a warning if the current one is worse (and under threshold) with default settings" in {
+    val currentFile = new File(getClass.getResource("/current_really_bad.csv").getPath)
+
+    checkComparisonDefaultThreshold(currentFile, benchmarkResultAgainstBadDefault)
+  }
+
+  private[this] def checkComparisonDefaultThreshold(
+      currentFile: File,
+      expected: List[BenchmarkComparisonResult]) = {
+    val result = SbtHoodPlugin
+      .benchmarkTask(
+        previousFile,
+        currentFile,
+        "Benchmark",
+        "Score",
+        "Score Error (99.9%)",
+        "Mode",
+        "Unit",
+        None,
+        Map.empty)
+      .value
+      .unsafeRunSync()
+
+    result.isRight shouldBe true
+    result.map { resultList =>
+      resultList.sortBy(_.previous.benchmark) shouldBe expected
+    }
+  }
+
+}

--- a/modules/plugin/src/test/scala/com.fortysevendeg.hood.plugin/TestUtils.scala
+++ b/modules/plugin/src/test/scala/com.fortysevendeg.hood.plugin/TestUtils.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scala.com.fortysevendeg.hood.plugin
+
+import com.fortysevendeg.hood.benchmark._
+import com.fortysevendeg.hood.model.{Benchmark, PrimaryMetric}
+
+trait TestUtils {
+
+  val prevBenchmarkDecoding =
+    Benchmark("test.decoding", "thrpt", PrimaryMetric(5.0, 3.0, "love/s", List.empty))
+  val prevBenchmarkParsing =
+    Benchmark("test.parsing", "thrpt", PrimaryMetric(6.0, 3.0, "love/s", List.empty))
+  val niceBenchmarkDecoding =
+    Benchmark("test.decoding", "thrpt", PrimaryMetric(6.0, 0.1, "love/s", List.empty))
+  val niceBenchmarkParsing =
+    Benchmark("test.parsing", "thrpt", PrimaryMetric(7.0, 0.1, "love/s", List.empty))
+  val notSoNiceBenchmarkDecoding =
+    Benchmark("test.decoding", "thrpt", PrimaryMetric(3.0, 0.1, "love/s", List.empty))
+  val notSoNiceBenchmarkParsing =
+    Benchmark("test.parsing", "thrpt", PrimaryMetric(4.0, 0.1, "love/s", List.empty))
+  val badBenchmarkDecoding =
+    Benchmark("test.decoding", "thrpt", PrimaryMetric(1.0, 0.1, "love/s", List.empty))
+  val badBenchmarkParsing =
+    Benchmark("test.parsing", "thrpt", PrimaryMetric(0.5, 0.1, "love/s", List.empty))
+
+  val benchmarkResultAgainstNiceDefault = List(
+    BenchmarkComparisonResult(prevBenchmarkDecoding, Some(niceBenchmarkDecoding), OK, 3.0),
+    BenchmarkComparisonResult(prevBenchmarkParsing, Some(niceBenchmarkParsing), OK, 3.0)
+  )
+
+  val benchmarkResultAgainstNotSoNiceDefault = List(
+    BenchmarkComparisonResult(
+      prevBenchmarkDecoding,
+      Some(notSoNiceBenchmarkDecoding),
+      Warning,
+      3.0),
+    BenchmarkComparisonResult(prevBenchmarkParsing, Some(notSoNiceBenchmarkParsing), Warning, 3.0)
+  )
+
+  val benchmarkResultAgainstBadDefault = List(
+    BenchmarkComparisonResult(prevBenchmarkDecoding, Some(badBenchmarkDecoding), Error, 3.0),
+    BenchmarkComparisonResult(prevBenchmarkParsing, Some(badBenchmarkParsing), Error, 3.0)
+  )
+
+}

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -35,6 +35,8 @@ object ProjectPlugin extends AutoPlugin {
       val log4cats: String        = "0.4.0-M1"
       val logbackClassic: String  = "1.2.3"
       val kantan: String          = "0.5.1"
+      val console4cats: String    = "0.8.0-M1"
+      val lightbendEmoji: String  = "1.2.1"
     }
 
     lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
@@ -113,6 +115,8 @@ object ProjectPlugin extends AutoPlugin {
         "ch.qos.logback"              % "logback-classic"        % V.logbackClassic,
         "com.nrinaudo"               %% "kantan.csv"             % V.kantan,
         "com.nrinaudo"               %% "kantan.csv-generic"     % V.kantan,
+        "dev.profunktor"             %% "console4cats"           % V.console4cats,
+        "com.lightbend"              %% "emoji"                  % V.lightbendEmoji,
         %%("scalatest", V.scalatest) % "test",
         %("slf4j-nop", V.slf4j)      % Test
       )


### PR DESCRIPTION
Fixes: #12 

This PR introduces the main sbt task (`compareBenchmarks`) and configuration keys for sbt-hood.  This task compares the two benchmarks provided by the user and shows the comparison result in the console. All config keys are currently implemented (except for those related to GitHub/`compareBenchmarksCI` that are not part for the MVP).

It also fixes a couple of issues with error handling when it comes to load the files from disk.