### PR TITLE
Output comparison report to a file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,3 @@ lazy val docs = project
   .settings(micrositeSettings: _*)
   .settings(noPublishSettings: _*)
   .enablePlugins(MicrositesPlugin)
-
-
-
-lazy val lel = thisProject.value.autoPlugins

--- a/build.sbt
+++ b/build.sbt
@@ -44,3 +44,7 @@ lazy val docs = project
   .settings(micrositeSettings: _*)
   .settings(noPublishSettings: _*)
   .enablePlugins(MicrositesPlugin)
+
+
+
+lazy val lel = thisProject.value.autoPlugins

--- a/docs/src/main/tut/sbthood/docs.md
+++ b/docs/src/main/tut/sbthood/docs.md
@@ -29,6 +29,9 @@ sbt variables:
 * `unitsColumnName`: column name to get the benchmark mode. By default: `Unit`.
 * `generalThreshold`: optional common threshold to all benchmarks overriding the value coming from `thresholdColumnName`.
 * `benchmarkThreshold`: optional map with a custom threshold per benchmark key overriding the value coming from `thresholdColumnName` or `generalThreshold`.
+* `outputToFile`: set to `true` saves the comparison results in a separate file in addition to the console report. By default this setting is disabled.
+* `outputPath`: path to the comparison report to be generated. By default: `{project_root}/comparison.md`.
+* `outputFormat`: file format for the comparison report. `MD` and `JSON` are supported. By default: `MD`.
 
 As you can see all these variables have default values or are optional so you'll just need to adapt
 some of these if your benchmark files are in CSV format and contain different column names. Once set
@@ -41,23 +44,25 @@ compareBenchmarks
 If no errors are found, you'll see the comparisons being output in the sbt console. i.e.:
 
 ```
-✔ test.decoding (Threshold: 4.0)
+# ✔ test.decoding (Threshold: 3.0)
 
-Benchmark|Value
-master.csv|5.0
-current.csv|7.0
+|Benchmark|Value|
+|---------|-----|
+|previous.json|5.0|
+|current_better.json|6.0|
+    
+# ✔ test.parsing (Threshold: 3.0)
 
-✔ test.parsing (Threshold: 1.0)
-
-Benchmark|Value
-master.csv|6.0
-current.csv|10.0
+|Benchmark|Value|
+|---------|-----|
+|previous.json|6.0|
+|current_better.json|7.0|
 ```
 
 For each benchmark (set by the value found under the specified `keyColumnName` variable) you'll see
 a table comparing the values of both files. Results can be of three types (visible by the icon that
 shows in each table):
 
-* Success: the current benchmark is better than the previous one.
-* Warning: the current benchmark is worse than the previous one, but within the specified threshold.
-* Error: the current benchmark is worse than the previous one, and outside the specified threshold.
+* Success (✔): the current benchmark is better than the previous one.
+* Warning (⚠): the current benchmark is worse than the previous one, but within the specified threshold.
+* Error (🔴): the current benchmark is worse than the previous one, and outside the specified threshold.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/benchmark/BenchmarkService.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/benchmark/BenchmarkService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/csv/CsvService.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/csv/CsvService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/github/GithubModel.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/github/GithubModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/github/GithubService.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/github/GithubService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/json/JsonService.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/json/JsonService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/model/Benchmark.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/model/Benchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/model/Benchmark.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/model/Benchmark.scala
@@ -28,6 +28,10 @@ final case class Benchmark(
 object Benchmark {
   implicit val benchmarkDecoder: Decoder[Benchmark] = deriveDecoder[Benchmark]
   implicit val benchmarkEncoder: Encoder[Benchmark] = deriveEncoder[Benchmark]
+  implicit val benchmarkOrdering: Ordering[Benchmark] = new Ordering[Benchmark] {
+    override def compare(x: Benchmark, y: Benchmark): Int =
+      x.benchmark.compareTo(y.benchmark)
+  }
 }
 
 final case class PrimaryMetric(

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/model/HoodError.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/model/HoodError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/model/HoodError.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/model/HoodError.scala
@@ -23,3 +23,4 @@ final case class MissingCurrentBenchmark(message: String) extends HoodError
 final case class BenchmarkLoadingError(message: String)   extends HoodError
 final case class MissingGitHubParameter(message: String)  extends HoodError
 final case class GitHubConnectionError(message: String)   extends HoodError
+final case class OutputFileError(message: String)         extends HoodError

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/model/JmhResult.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/model/JmhResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
@@ -17,7 +17,8 @@
 package com.fortysevendeg.hood.utils
 
 import cats.effect.{Resource, Sync}
-import java.io.File
+import java.io.{File, PrintWriter}
+import cats.syntax.either._
 
 import scala.io.{BufferedSource, Source}
 
@@ -46,6 +47,15 @@ object FileUtils {
     } else if (Json.extensions.contains(fileExtension(file))) {
       Json
     } else Unknown
+
+  def writeFile[F[_]](file: File, contents: String)(
+      implicit S: Sync[F]): F[Either[Throwable, Unit]] = S.delay {
+    Either.catchNonFatal {
+      val writer = new PrintWriter(file)
+      writer.write(contents)
+      writer.close()
+    }
+  }
 
   private[this] def fileExtension(file: File): String =
     file.getName.toLowerCase.split('.').lastOption.getOrElse("")

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
@@ -49,13 +49,10 @@ object FileUtils {
     } else Unknown
 
   def writeFile[F[_]](file: File, contents: String)(
-      implicit S: Sync[F]): F[Either[Throwable, Unit]] = S.delay {
-    Either.catchNonFatal {
-      val writer = new PrintWriter(file)
-      writer.write(contents)
-      writer.close()
-    }
-  }
+      implicit S: Sync[F]): F[Either[Throwable, Unit]] =
+    S.attempt(
+      S.bracket(S.pure(new PrintWriter(file)))(writer => S.pure(writer.write(contents)))(writer =>
+        S.pure(writer.close())))
 
   private[this] def fileExtension(file: File): String =
     file.getName.toLowerCase.split('.').lastOption.getOrElse("")

--- a/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
+++ b/modules/core/src/main/scala/com/fortysevendeg/hood/utils/FileUtils.scala
@@ -18,7 +18,7 @@ package com.fortysevendeg.hood.utils
 
 import cats.effect.{Resource, Sync}
 import java.io.{File, PrintWriter}
-import cats.syntax.either._
+import cats.implicits._
 
 import scala.io.{BufferedSource, Source}
 
@@ -51,8 +51,8 @@ object FileUtils {
   def writeFile[F[_]](file: File, contents: String)(
       implicit S: Sync[F]): F[Either[Throwable, Unit]] =
     S.attempt(
-      S.bracket(S.pure(new PrintWriter(file)))(writer => S.pure(writer.write(contents)))(writer =>
-        S.pure(writer.close())))
+      S.bracket(S.delay(new PrintWriter(file)))(writer => S.delay(writer.write(contents)))(writer =>
+        S.delay(writer.close())))
 
   private[this] def fileExtension(file: File): String =
     file.getName.toLowerCase.split('.').lastOption.getOrElse("")

--- a/modules/core/src/test/scala/com/fortysevendeg/hood/TestValues.scala
+++ b/modules/core/src/test/scala/com/fortysevendeg/hood/TestValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/test/scala/com/fortysevendeg/hood/benchmark/BenchmarkServiceTests.scala
+++ b/modules/core/src/test/scala/com/fortysevendeg/hood/benchmark/BenchmarkServiceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/test/scala/com/fortysevendeg/hood/csv/CsvServiceTests.scala
+++ b/modules/core/src/test/scala/com/fortysevendeg/hood/csv/CsvServiceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/test/scala/com/fortysevendeg/hood/json/JsonServiceTests.scala
+++ b/modules/core/src/test/scala/com/fortysevendeg/hood/json/JsonServiceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodKeys.scala
@@ -45,6 +45,12 @@ trait SbtHoodKeys {
     "Common threshold to all benchmarks overriding the value coming from `thresholdColumnName`. Optional.")
   val benchmarkThreshold: SettingKey[Map[String, Double]] = settingKey(
     "Map with a custom threshold per benchmark key overriding the value coming from `thresholdColumnName` or `generalThreshold`. Optional.")
+  val outputToFile: SettingKey[Boolean] = settingKey(
+    "True if sbt-hood should write the benchmark output to a file. By default: `false`.")
+  val outputPath: SettingKey[File] = settingKey(
+    "Path to the output file. By default: `{project_root}/comparison.md`")
+  val outputFormat: SettingKey[String] = settingKey(
+    "Output file format. `MD` and `JSON` are supported. By default: `MD`")
 
   val gitHubToken: SettingKey[Option[String]] = settingKey(
     "GitHub access token required by `compareBenchmarksCI`.")
@@ -75,6 +81,9 @@ trait SbtHoodDefaultSettings extends SbtHoodKeys {
     unitsColumnName := "Unit",
     generalThreshold := None,
     benchmarkThreshold := Map.empty,
+    outputToFile := false,
+    outputPath := baseDirectory.value / "comparison.md",
+    outputFormat := "MD",
     gitHubToken := None,
     gitHubUserId := None,
     repositoryOwner := None,

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -255,9 +255,9 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
         case OutputFileFormatMd   => benchmarkOutput(benchmarksResults, previousFile, currentFile)
       }
 
-      FileUtils
-        .writeFile(outputPath, fileContents)
-        .map(r => r.leftMap(e => OutputFileError(e.getMessage)))
+      EitherT(FileUtils.writeFile(outputPath, fileContents))
+        .leftMap[HoodError](e => OutputFileError(e.getMessage))
+        .value
     } else S.pure(Either.right(()))
 
   def collectBenchmarks(

--- a/modules/plugin/src/test/scala/com/fortysevendeg/hood/plugin/TestUtils.scala
+++ b/modules/plugin/src/test/scala/com/fortysevendeg/hood/plugin/TestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -37,7 +37,6 @@ object ProjectPlugin extends AutoPlugin {
       val kantan: String          = "0.5.1"
       val console4cats: String    = "0.8.0-M1"
       val lightbendEmoji: String  = "1.2.1"
-      val monocleMacro: String    = "2.0.0"
     }
 
     lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
@@ -119,7 +118,6 @@ object ProjectPlugin extends AutoPlugin {
         "com.nrinaudo"               %% "kantan.csv-generic"     % V.kantan,
         "dev.profunktor"             %% "console4cats"           % V.console4cats,
         "com.lightbend"              %% "emoji"                  % V.lightbendEmoji,
-        "com.github.julien-truffaut" %% "monocle-macro"          % V.monocleMacro,
         %%("scalatest", V.scalatest) % "test",
         %("slf4j-nop", V.slf4j)      % Test
       )

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -37,6 +37,7 @@ object ProjectPlugin extends AutoPlugin {
       val kantan: String          = "0.5.1"
       val console4cats: String    = "0.8.0-M1"
       val lightbendEmoji: String  = "1.2.1"
+      val monocleMacro: String    = "2.0.0"
     }
 
     lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
@@ -118,6 +119,7 @@ object ProjectPlugin extends AutoPlugin {
         "com.nrinaudo"               %% "kantan.csv-generic"     % V.kantan,
         "dev.profunktor"             %% "console4cats"           % V.console4cats,
         "com.lightbend"              %% "emoji"                  % V.lightbendEmoji,
+        "com.github.julien-truffaut" %% "monocle-macro"          % V.monocleMacro,
         %%("scalatest", V.scalatest) % "test",
         %("slf4j-nop", V.slf4j)      % Test
       )


### PR DESCRIPTION
Fixes #7 

This PR adds a feature to generate a report file to be saved to disk that contains the results of the benchmarks comparison. 