### PR TITLE
Bumping up version to release 0.1.0 and adding microsite publish settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ project/plugins/project/
 .bloop/
 .metals/
 project/.bloop/
+
+# sbt-microsite specific
+_site/

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ stages:
 - test
 - plugin
 - deploy
-- microsite
 jobs:
   include:
     - stage: plugin
@@ -52,12 +51,5 @@ jobs:
             git pull origin master;
             sbt ";project sbt-hood-plugin;release";
             sbt release;
-          fi
-    - stage: microsite
-      if: branch = master AND type != pull_request
-      script:
-        - if grep -q "SNAPSHOT" version.sbt; then
-            echo "Skipping microsite publication, snapshot version";
-          else
-            echo "Not ready yet! (sbt docs/publishMicrosite)";
+            sbt docs/publishMicrosite;
           fi

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2-SNAPSHOT"
+version in ThisBuild := "0.1.0"


### PR DESCRIPTION
This PR adds the microsite publish step to our Travis configuration file, and bumps the version to 0.1.0 to release the plugin for public announcement.