### PR TITLE
Bumping up Jekyll version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ cache:
 before_install:
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_8d91199f8619_key -iv $encrypted_8d91199f8619_iv -in secring.gpg.enc -out secring.gpg -d; fi
 install:
-  - rvm use 2.3.0 --install --fuzzy
+  - rvm use 2.6.5 --install --fuzzy
   - gem install sass
-  - gem install jekyll -v 3.2.1
+  - gem install jekyll -v 4
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport coverageAggregate docs/tut
   - bash <(curl -s https://codecov.io/bash)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -22,7 +22,7 @@ In order to use *sbt-hood* you simply have to specify what benchmark files do yo
 sbt variables:
 
 * `previousBenchmarkPath`: path to the previous JMH benchmark in CSV/Json format. By default: `{project_root}/master.csv`.
-* `currentBenchmarkPath`: path to the current JMH benchmark in CSV/Json format.  By default: ``{project_root}/current.csv`.
+* `currentBenchmarkPath`: path to the current JMH benchmark in CSV/Json format.  By default: `{project_root}/current.csv`.
 * `keyColumnName`: column name to distinguish each benchmark on the comparison. By default: `Benchmark`.
 * `include`: regular expression to include only the benchmarks with a matching key. Optional.
 * `exclude`: regular expression to exclude the benchmarks with a matching key. Optional.

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -4,3 +4,6 @@ options:
 
   - title: GitHub integration
     url: /github-integration/
+
+  - title: Hood home
+    url: https://47deg.github.io/hood/

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -56,7 +56,7 @@ object ProjectPlugin extends AutoPlugin {
     )
 
     lazy val micrositeSettings: Seq[Def.Setting[_]] = Seq(
-      micrositeName := "Sbt-hood",
+      micrositeName := "SBT-Hood",
       micrositeBaseUrl := "/sbt-hood",
       micrositeDescription := "A SBT plugin for comparing benchmarks in your PRs",
       micrositeGithubOwner := "47deg",


### PR DESCRIPTION
This PR bumps up the version of Jekyll in the Travis configuration, trying to fix the current issues with styles and relative links in the microsite.