### PR TITLE
Bumping version up to reflect changes in tasks naming

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"
+version in ThisBuild := "0.2.0"


### PR DESCRIPTION
This PR bumps up the library version to reflect the changes in the naming of `uploadBenchmarks` task fixed by @AdrianRaFo in https://github.com/47deg/sbt-hood/pull/31.