### PR TITLE
Adds /hood/sbt prefix in the micrositeBaseUrl setting

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -52,7 +52,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val micrositeSettings: Seq[Def.Setting[_]] = Seq(
       micrositeName := "SBT-Hood",
-      micrositeBaseUrl := "/sbt",
+      micrositeBaseUrl := "/hood/sbt",
       micrositeDescription := "A SBT plugin for comparing benchmarks in your PRs",
       micrositeGithubOwner := "47deg",
       micrositeGithubRepo := "sbt-hood",


### PR DESCRIPTION
Now the docs urls for Hood will be:
`Graddle-Hood: https://47deg.github.io/hood/gradle/`
`SBT-Hood: https://47deg.github.io/hood/sbt/`
That way keeps coherence.